### PR TITLE
Add mock API test helper for mock mode

### DIFF
--- a/src/api/mock/testMockApi.ts
+++ b/src/api/mock/testMockApi.ts
@@ -1,0 +1,10 @@
+import { callApi } from './index';
+
+export async function testMockApi(): Promise<void> {
+  const { chats } = await callApi<{ chats: unknown[] }>('fetchChats', 20);
+  if (!Array.isArray(chats)) {
+    throw new Error('Mock API fetchChats returned invalid data');
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Fetched ${chats.length} chats from mock API`);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ import './assets/fonts/roboto.css';
 import './styles/index.scss';
 
 // Import mock API test function for debugging
-import { testMockApi } from './api/mock/test';
+import { testMockApi } from './api/mock/testMockApi';
 
 if (STRICTERDOM_ENABLED) {
   enableStrict();


### PR DESCRIPTION
## Summary
- fix broken import path by adding testMockApi helper
- run a basic mock API call to verify mock API returns chats

## Testing
- `NODE_OPTIONS="" node ./node_modules/jest/bin/jest.js --verbose --forceExit`

------
https://chatgpt.com/codex/tasks/task_b_68a0158e79408322a413c80dc458cbea