### PR TITLE
Fix language change spinner never ending

### DIFF
--- a/src/components/auth/AuthPhoneNumber.tsx
+++ b/src/components/auth/AuthPhoneNumber.tsx
@@ -143,14 +143,15 @@ const AuthPhoneNumber: FC<StateProps> = ({
     setPhoneNumber(formatPhoneNumber(newFullNumber, selectedCountry));
   });
 
-  const handleLangChange = useLastCallback(() => {
+  const handleLangChange = useLastCallback(async () => {
     markIsLoading();
 
-    void oldSetLanguage(suggestedLanguage, () => {
-      unmarkIsLoading();
-
+    try {
+      await oldSetLanguage(suggestedLanguage);
       setSharedSettingOption({ language: suggestedLanguage });
-    });
+    } finally {
+      unmarkIsLoading();
+    }
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure language-change button always clears loading state even if mock call fails

## Testing
- `npm test --node-options=''`

------
https://chatgpt.com/codex/tasks/task_b_68a01ad0aa7c8322bdd0ccd231d6cb7d