### PR TITLE
Fix mock auth init to send authorization state

### DIFF
--- a/src/api/mock/index.ts
+++ b/src/api/mock/index.ts
@@ -37,9 +37,14 @@ class MockApi {
         '@type': 'updateConnectionState',
         connectionState: 'connectionStateReady',
       });
-      
+
       this.updateCallback?.({
         '@type': 'updateApiReady',
+      });
+
+      this.updateCallback?.({
+        '@type': 'updateAuthorizationState',
+        authorizationState: mockAuth.getCurrentAuthState(),
       });
     }, 1000);
   }


### PR DESCRIPTION
## Summary
- Ensure mock API initializes authorization state so login can proceed

## Testing
- `npm test --node-options=""`


------
https://chatgpt.com/codex/tasks/task_b_68a01fac386c83229d7f4510954cc7a2