### PR TITLE
Fix mock auth phone flow

### DIFF
--- a/src/api/mock/index.test.ts
+++ b/src/api/mock/index.test.ts
@@ -1,9 +1,14 @@
 declare const console: any;
-import { callApi } from './index';
+import { callApi, mockAuth } from './index';
 
 describe('Mock API', () => {
   test('fetchChats returns data', async () => {
     const chats = await callApi('fetchChats', 20);
     expect(chats).toBeDefined();
+  });
+
+  test('provideAuthPhoneNumber updates mock phone', async () => {
+    await callApi('provideAuthPhoneNumber', '1234567890');
+    expect(mockAuth.getMockPhoneNumber()).toBe('1234567890');
   });
 });

--- a/src/api/mock/index.ts
+++ b/src/api/mock/index.ts
@@ -85,12 +85,15 @@ class MockApi {
       case 'searchMessages':
         return mockMessages.mockSearchMessages(args[0], args[1]) as T;
       
+      case 'provideAuthPhoneNumber':
       case 'signIn':
         return mockAuth.mockSignIn(args[0], this.updateCallback!) as T;
+      case 'provideAuthCode':
       case 'submitCode':
         return mockAuth.mockSubmitCode(args[0], this.updateCallback!) as T;
       case 'signUp':
         return mockAuth.mockSignUp(args[0], args[1], this.updateCallback!) as T;
+      case 'provideAuthPassword':
       case 'signInWithPassword':
         return mockAuth.mockSignInWithPassword(args[0], this.updateCallback!) as T;
       


### PR DESCRIPTION
## Summary
- support provideAuthPhoneNumber, provideAuthCode and provideAuthPassword in mock API
- test phone number submission in mock API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a02abdf8488322b7b027817817588d