### PR TITLE
feat: accept any auth code in mock

### DIFF
--- a/Auth-API.md
+++ b/Auth-API.md
@@ -1,0 +1,66 @@
+# Authentication API
+
+This document outlines the minimum backend API required to replace the mocked authentication flow.
+The frontend interacts with these endpoints through `callApi()` methods such as `signIn` and
+`submitCode`.
+
+Base URL: `https://your-backend.example.com`
+
+## `POST /auth/send-code`
+Send an authentication code to the supplied phone number.
+
+**Request body**
+```json
+{
+  "phoneNumber": "+1 988 671 6821"
+}
+```
+
+**Response**
+```json
+{
+  "sessionId": "string" // identifier to be used for the next step
+}
+```
+
+The backend should forward the request to Telegram's `auth.sendCode` method or an equivalent
+provider.
+
+## `POST /auth/verify-code`
+Verify the code entered by the user and create an authenticated session.
+
+**Request body**
+```json
+{
+  "sessionId": "string",
+  "code": "12345"
+}
+```
+
+**Response**
+```json
+{
+  "token": "string", // session token
+  "user": { ... }     // authorized user data
+}
+```
+
+On success the frontend will transition to the next screen. Errors should return a non‑200 status
+with an error description.
+
+## Testing
+
+- **Mock mode:** run `npm run dev:mocked`. Any code will be accepted and the app will
+  proceed to the next screen.
+- **Real API:** use `curl` or Postman to verify the endpoints:
+  ```bash
+  curl -X POST https://your-backend.example.com/auth/send-code \
+       -H "Content-Type: application/json" \
+       -d '{"phoneNumber":"+19886716821"}'
+
+  curl -X POST https://your-backend.example.com/auth/verify-code \
+       -H "Content-Type: application/json" \
+       -d '{"sessionId":"<id>","code":"12345"}'
+  ```
+
+Implementing these endpoints completes the authentication flow without the mock layer.

--- a/src/api/mock/auth.ts
+++ b/src/api/mock/auth.ts
@@ -46,27 +46,14 @@ export async function mockSignIn(phoneNumber: string, onUpdate: OnApiUpdate): Pr
 
 export async function mockSubmitCode(code: string, onUpdate: OnApiUpdate): Promise<void> {
   mockSetCode(code);
-  
-  // Simulate code validation
-  if (code !== '12345') {
-    onUpdate({
-      '@type': 'updateAuthorizationError',
-      error: {
-        message: 'Invalid code',
-        isSlowMode: false,
-        hasErrorKey: true,
-      },
-    });
-    return;
-  }
 
-  // Simulate successful authentication
+  // Always simulate successful authentication for any code
   setTimeout(() => {
     onUpdate({
       '@type': 'updateAuthorizationState',
       authorizationState: 'authorizationStateReady',
     });
-    
+
     onUpdate({
       '@type': 'updateCurrentUser',
       user: {


### PR DESCRIPTION
## Summary
- allow any code to succeed in mock authentication flow
- document auth endpoints and testing in Auth-API.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a02e9942148322b3f885c1ea17ae2e