### PR TITLE
Fix mock API to avoid runtime errors during login

### DIFF
--- a/src/api/mock/auth.ts
+++ b/src/api/mock/auth.ts
@@ -56,14 +56,17 @@ export async function mockSubmitCode(code: string, onUpdate: OnApiUpdate): Promi
 
     onUpdate({
       '@type': 'updateCurrentUser',
-      user: {
+      currentUser: {
         id: 'currentUser',
+        type: 'userTypeRegular',
+        isMin: false,
         firstName: 'Mock',
         lastName: 'User',
         username: 'mockuser',
         phoneNumber: mockPhoneNumber,
         isPremium: false,
       },
+      currentUserFullInfo: {},
     });
   }, 1000);
 }
@@ -75,17 +78,20 @@ export async function mockSignUp(firstName: string, lastName: string, onUpdate: 
       '@type': 'updateAuthorizationState',
       authorizationState: 'authorizationStateReady',
     });
-    
+
     onUpdate({
       '@type': 'updateCurrentUser',
-      user: {
+      currentUser: {
         id: 'currentUser',
+        type: 'userTypeRegular',
+        isMin: false,
         firstName,
         lastName,
         username: 'newuser',
         phoneNumber: mockPhoneNumber,
         isPremium: false,
       },
+      currentUserFullInfo: {},
     });
   }, 1000);
 }

--- a/src/api/mock/chats.ts
+++ b/src/api/mock/chats.ts
@@ -4,25 +4,17 @@ import type { OnApiUpdate } from '../types/updates';
 const mockChats = [
   {
     id: '1',
-    type: 'chat',
+    type: 'chats',
     title: 'Mock Chat 1',
     unreadCount: 5,
-    lastMessage: {
-      text: 'Hello from mock API',
-      date: Date.now(),
-    },
     isPinned: false,
     isArchived: false,
   },
   {
     id: '2',
-    type: 'channel',
+    type: 'channels',
     title: 'Mock Channel',
     unreadCount: 0,
-    lastMessage: {
-      text: 'Channel message',
-      date: Date.now() - 3600000,
-    },
     isPinned: true,
     isArchived: false,
   },
@@ -31,11 +23,21 @@ const mockChats = [
 export async function mockFetchChats(limit: number = 20, offsetDate?: number, offsetId?: number) {
   // Simulate API delay
   await new Promise(resolve => setTimeout(resolve, 500));
-  
+
   return {
     chats: mockChats,
     users: [],
     chatIds: mockChats.map(chat => chat.id),
+    messages: [],
+    userStatusesById: {},
+    notifyExceptionById: {},
+    lastMessageByChatId: {},
+    nextOffsetId: undefined,
+    nextOffsetPeerId: undefined,
+    nextOffsetDate: undefined,
+    draftsById: {},
+    orderedPinnedIds: [],
+    totalChatCount: mockChats.length,
   };
 }
 

--- a/src/api/mock/index.ts
+++ b/src/api/mock/index.ts
@@ -117,7 +117,13 @@ class MockApi {
         return this.mockFetchNearestCountry(args) as T;
       case 'fetchCountryList':
         return this.mockFetchCountryList(args) as T;
-      
+      case 'fetchCustomEmoji':
+        return [] as T;
+      case 'fetchChatFolders':
+        return {} as T;
+      case 'fetchRecommendedChatFolders':
+        return {} as T;
+
       default:
         return this.mockGenericResponse(method, args) as T;
     }


### PR DESCRIPTION
## Summary
- provide proper current user update in mock auth flow
- stub missing mock API methods to return expected shapes
- return complete chat data structure from mock fetch

## Testing
- `npm test` *(fails: node: --no-experimental-strip-types is not allowed in NODE_OPTIONS)*

------
https://chatgpt.com/codex/tasks/task_b_68a032aeebd08322b700c994738cacd3