### PR TITLE
Improve API mocks and document main window API

### DIFF
--- a/MAIN-API.md
+++ b/MAIN-API.md
@@ -1,0 +1,141 @@
+# Main Window API
+
+This document describes the minimal backend API required to replace the mocked
+main window data.  The frontend currently uses local mocks defined in
+`src/api/mock/index.ts` for these endpoints.  Implementing the endpoints below
+will allow the application to work without the mock layer.
+
+Base URL: `https://your-backend.example.com`
+
+## `GET /config`
+Returns general configuration used across the app.
+
+**Response**
+```json
+{
+  "expiresAt": 1714042140,
+  "limits": { "moreAccounts": [3, 4], ... }
+}
+```
+`limits` should follow the structure of Telegram's `help.getAppConfig` limits.
+
+## `GET /app-config`
+Provides UI related configuration such as feature limits.
+
+**Response**
+```json
+{
+  "hash": "string",
+  "limits": { "moreAccounts": [3, 4], ... }
+}
+```
+
+## `GET /chats`
+Fetches list of chats.
+
+**Query params**: `limit`, `offsetDate`, `offsetId`
+
+**Response**
+```json
+{
+  "chats": [ {"id": "1", "title": "Chat"} ],
+  "users": [],
+  "chatIds": ["1"],
+  "messages": [],
+  "totalChatCount": 1
+}
+```
+
+## `GET /stories`
+Returns story metadata.
+
+**Response**
+```json
+{ "state": "string", "peerStories": [], "stealthMode": {}, "hasMore": false }
+```
+
+## `GET /content-settings`
+Content restriction settings for the current user.
+
+**Response**
+```json
+{ "isSensitiveEnabled": false }
+```
+
+## `GET /peer-colors`
+Returns color map for peers.
+
+**Response**
+```json
+{ "hash": "0", "colors": { "peerId": "#aabbcc" } }
+```
+
+## `GET /sticker-sets`
+Returns installed sticker sets.
+
+**Response**
+```json
+{ "hash": "0", "sets": [] }
+```
+
+## `GET /custom-emoji-sets`
+Returns installed custom emoji sets.
+
+**Response**
+```json
+{ "hash": "0", "sets": [] }
+```
+
+## `GET /contacts`
+Returns user's contact list.
+
+**Response**
+```json
+{ "users": [], "userStatusesById": {} }
+```
+
+## `GET /me`
+Returns current user information.
+
+**Response**
+```json
+{ "user": {"id": "currentUser", "firstName": "Mock"}, "userFullInfo": {} }
+```
+
+## `GET /authorizations`
+Active session information.
+
+**Response**
+```json
+{ "authorizations": {}, "ttlDays": 30 }
+```
+
+## `GET /stars/status`
+Returns Star or TON balance depending on query parameter `isTon`.
+
+**Response**
+```json
+{ "balance": { "amount": 0, "currency": "stars" }, "history": [] }
+```
+
+## `GET /collectible-emoji-statuses`
+Returns available collectible emoji statuses.
+
+**Response**
+```json
+{ "hash": "0", "statuses": [] }
+```
+
+## `GET /featured-emoji-stickers`
+Returns featured emoji sticker sets.
+
+**Response**
+```json
+{ "sets": [] }
+```
+
+## Replacing the mocks
+The mock layer can be removed by wiring `callApi` to the real backend.  Each of
+the endpoints above should mirror the response shapes used by the mocks.  Once
+implemented, update `src/api/index.ts` to call your backend instead of the mock
+implementation.

--- a/src/api/mock/index.ts
+++ b/src/api/mock/index.ts
@@ -3,6 +3,7 @@ import type { OnApiUpdate } from '../types/updates';
 import * as mockAuth from './auth';
 import * as mockChats from './chats';
 import * as mockMessages from './messages';
+import { DEFAULT_LIMITS, STARS_CURRENCY_CODE, TON_CURRENCY_CODE } from '../../config';
 
 // Re-export all types for compatibility
 export * from '../types';
@@ -123,6 +124,42 @@ class MockApi {
         return {} as T;
       case 'fetchRecommendedChatFolders':
         return {} as T;
+      case 'fetchConfig':
+        return this.mockFetchConfig() as T;
+      case 'fetchAppConfig':
+        return this.mockFetchAppConfig() as T;
+      case 'fetchSavedChats':
+        return mockChats.mockFetchChats(args[0]?.limit, args[0]?.offsetDate, args[0]?.offsetId) as T;
+      case 'fetchAllStories':
+        return this.mockFetchAllStories() as T;
+      case 'fetchContentSettings':
+        return this.mockFetchContentSettings() as T;
+      case 'fetchPeerColors':
+        return this.mockFetchPeerColors() as T;
+      case 'fetchStickerSets':
+        return this.mockFetchStickerSets() as T;
+      case 'fetchCustomEmojiSets':
+        return this.mockFetchCustomEmojiSets() as T;
+      case 'fetchContactList':
+        return this.mockFetchContactList() as T;
+      case 'fetchCurrentUser':
+        return this.mockFetchCurrentUser() as T;
+      case 'fetchAuthorizations':
+        return this.mockFetchAuthorizations() as T;
+      case 'fetchStarsStatus':
+        return this.mockFetchStarsStatus(args[0]) as T;
+      case 'fetchStarsTopupOptions':
+        return [] as T;
+      case 'fetchCollectibleEmojiStatuses':
+        return this.mockFetchCollectibleEmojiStatuses() as T;
+      case 'fetchAnimatedEmojis':
+        return [] as T;
+      case 'fetchAnimatedEmojiEffects':
+        return [] as T;
+      case 'fetchFeaturedEmojiStickers':
+        return this.mockFetchFeaturedEmojiStickers() as T;
+      case 'updateIsOnline':
+        return { success: true } as T;
 
       default:
         return this.mockGenericResponse(method, args) as T;
@@ -278,6 +315,78 @@ class MockApi {
     }));
 
     return Promise.resolve({ phoneCodes, general });
+  }
+
+  private mockFetchConfig() {
+    return Promise.resolve({
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      limits: DEFAULT_LIMITS,
+    });
+  }
+
+  private mockFetchAppConfig() {
+    return Promise.resolve({
+      hash: '0',
+      limits: DEFAULT_LIMITS,
+    });
+  }
+
+  private mockFetchAllStories() {
+    return Promise.resolve({ state: '0', peerStories: [], stealthMode: {}, hasMore: false });
+  }
+
+  private mockFetchContentSettings() {
+    return Promise.resolve({ isSensitiveEnabled: false });
+  }
+
+  private mockFetchPeerColors() {
+    return Promise.resolve({ colors: {}, hash: '0' });
+  }
+
+  private mockFetchStickerSets() {
+    return Promise.resolve({ hash: '0', sets: [] });
+  }
+
+  private mockFetchCustomEmojiSets() {
+    return Promise.resolve({ hash: '0', sets: [] });
+  }
+
+  private mockFetchContactList() {
+    return Promise.resolve({ users: [], userStatusesById: {} });
+  }
+
+  private mockFetchCurrentUser() {
+    return Promise.resolve({
+      user: {
+        id: 'currentUser',
+        firstName: 'Mock',
+        lastName: 'User',
+        username: 'mockuser',
+        phoneNumber: mockAuth.getMockPhoneNumber(),
+        isSelf: true,
+      },
+      userFullInfo: {},
+    });
+  }
+
+  private mockFetchAuthorizations() {
+    return Promise.resolve({ authorizations: {}, ttlDays: 30 });
+  }
+
+  private mockFetchStarsStatus(args: any[]) {
+    const isTon = args && args[0] && args[0].isTon;
+    return Promise.resolve({
+      balance: { amount: 0, currency: isTon ? TON_CURRENCY_CODE : STARS_CURRENCY_CODE },
+      history: [],
+    });
+  }
+
+  private mockFetchCollectibleEmojiStatuses() {
+    return Promise.resolve({ hash: '0', statuses: [] });
+  }
+
+  private mockFetchFeaturedEmojiStickers() {
+    return Promise.resolve({ sets: [] });
   }
 
   private mockGenericResponse(method: string, args: any[]) {


### PR DESCRIPTION
## Summary
- expand mocked API to cover configuration, stories, stickers, contacts and more
- add placeholder implementations for stars and user/session endpoints
- document required backend endpoints in `MAIN-API.md`

## Testing
- `npm test --node-options=""`


------
https://chatgpt.com/codex/tasks/task_b_68a03732effc8322ab0966b49fe37f3c