### PR TITLE
Handle undefined collections in iteratee utilities

### DIFF
--- a/src/util/iteratees.test.ts
+++ b/src/util/iteratees.test.ts
@@ -1,0 +1,16 @@
+import { buildCollectionByKey, buildCollectionByCallback } from './iteratees';
+
+describe('iteratees utilities', () => {
+  interface Item { id: number; value: string }
+
+  test('buildCollectionByKey handles undefined collection', () => {
+    const result = buildCollectionByKey<Item>(undefined, 'id');
+    expect(result).toEqual({});
+  });
+
+  test('buildCollectionByCallback handles undefined collection', () => {
+    const callback = (item: Item) => [item.id, item.value] as [number, string];
+    const result = buildCollectionByCallback<Item, number, string>(undefined, callback);
+    expect(result).toEqual({});
+  });
+});

--- a/src/util/iteratees.ts
+++ b/src/util/iteratees.ts
@@ -6,8 +6,11 @@ type OrderDirection =
 
 type OrderCallback<T> = (member: T) => unknown;
 
-export function buildCollectionByKey<T extends AnyLiteral>(collection: T[], key: keyof T) {
-  return collection.reduce((byKey: CollectionByKey<T>, member: T) => {
+export function buildCollectionByKey<T extends AnyLiteral>(
+  collection: T[] | undefined,
+  key: keyof T,
+) {
+  return (collection ?? []).reduce((byKey: CollectionByKey<T>, member: T) => {
     byKey[member[key]] = member;
 
     return byKey;
@@ -15,10 +18,10 @@ export function buildCollectionByKey<T extends AnyLiteral>(collection: T[], key:
 }
 
 export function buildCollectionByCallback<T extends AnyLiteral, K extends number | string, R>(
-  collection: T[],
+  collection: T[] | undefined,
   callback: (member: T) => [K, R],
 ) {
-  return collection.reduce((byKey: Record<K, R>, member: T) => {
+  return (collection ?? []).reduce((byKey: Record<K, R>, member: T) => {
     const [key, value] = callback(member);
     byKey[key] = value;
 


### PR DESCRIPTION
## Summary
- allow `buildCollectionByKey` and `buildCollectionByCallback` to handle undefined collections gracefully
- cover util functions with new tests

## Testing
- `./node_modules/.bin/jest --verbose --silent --forceExit`

------
https://chatgpt.com/codex/tasks/task_b_68a03c17fe188322a42c4eb8487c2095