### PR TITLE
Add mock reactions and effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Obtain API ID and API hash on [my.telegram.org](https://my.telegram.org) and pop
 npm run dev
 ```
 
+### Mock API
+
+The development mock now supports `fetchAvailableReactions` and `fetchAvailableEffects`.
+These endpoints return placeholder data so reactions and effects work without a backend.
+
 ### Invoking API from console
 
 Start your dev server and locate GramJS worker in console context.

--- a/src/api/mock/index.ts
+++ b/src/api/mock/index.ts
@@ -156,6 +156,10 @@ class MockApi {
         return [] as T;
       case 'fetchAnimatedEmojiEffects':
         return [] as T;
+      case 'fetchAvailableReactions':
+        return this.mockFetchAvailableReactions() as T;
+      case 'fetchAvailableEffects':
+        return this.mockFetchAvailableEffects() as T;
       case 'fetchFeaturedEmojiStickers':
         return this.mockFetchFeaturedEmojiStickers() as T;
       case 'updateIsOnline':
@@ -383,6 +387,34 @@ class MockApi {
 
   private mockFetchCollectibleEmojiStatuses() {
     return Promise.resolve({ hash: '0', statuses: [] });
+  }
+
+  private mockFetchAvailableReactions() {
+    return Promise.resolve([
+      {
+        reaction: { type: 'emoji', emoticon: '👍' },
+        title: 'Thumbs Up',
+      },
+      {
+        reaction: { type: 'emoji', emoticon: '❤️' },
+        title: 'Heart',
+      },
+    ]);
+  }
+
+  private mockFetchAvailableEffects() {
+    return Promise.resolve({
+      effects: [
+        {
+          id: '1',
+          emoticon: '🔥',
+          effectAnimationId: 'anim1',
+          effectStickerId: 'sticker1',
+        },
+      ],
+      emojis: [],
+      stickers: [],
+    });
   }
 
   private mockFetchFeaturedEmojiStickers() {

--- a/src/components/left/main/LeftSideMenuItems.tsx
+++ b/src/components/left/main/LeftSideMenuItems.tsx
@@ -92,7 +92,10 @@ const LeftSideMenuItems = ({
 
   const archivedUnreadChatsCount = useFolderManagerForUnreadCounters()[ARCHIVED_FOLDER_ID]?.chatsCount || 0;
 
-  const bots = useMemo(() => Object.values(attachBots).filter((bot) => bot.isForSideMenu), [attachBots]);
+  const bots = useMemo(
+    () => Object.values(attachBots || {}).filter((bot) => bot.isForSideMenu),
+    [attachBots],
+  );
 
   const handleSelectMyProfile = useLastCallback(() => {
     openChatWithInfo({ id: currentUserId, shouldReplaceHistory: true, profileTab: 'stories' });


### PR DESCRIPTION
## Summary
- Add mock handlers for `fetchAvailableReactions` and `fetchAvailableEffects`
- Safeguard side menu bots list when attachBots missing
- Document mock reactions and effects in README

## Testing
- `npm test --node-options=""`

------
https://chatgpt.com/codex/tasks/task_b_68a0401f481c83229bda2a3fc3ca7c5e