### PR TITLE
Handle missing chats in mock API and document push limitation

### DIFF
--- a/PUSH_NOTIFICATIONS.md
+++ b/PUSH_NOTIFICATIONS.md
@@ -1,0 +1,7 @@
+# Push Notifications
+
+During development the application may log:
+
+`[PUSH] Unable to subscribe to push. NotAllowedError: Registration failed - permission denied`
+
+Browsers only allow push subscriptions from secure origins and with explicit notification permissions. Ensure the app is served over HTTPS and the user grants notification access. In the mock environment this error can be ignored or push features can be disabled.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm run dev
 The development mock now supports `fetchAvailableReactions` and `fetchAvailableEffects`.
 These endpoints return placeholder data so reactions and effects work without a backend.
 
+`fetchChat` automatically generates a placeholder when a requested chat ID is missing, preventing runtime `Chat not found` errors during development.
+
 ### Invoking API from console
 
 Start your dev server and locate GramJS worker in console context.

--- a/src/api/mock/chats.ts
+++ b/src/api/mock/chats.ts
@@ -42,13 +42,21 @@ export async function mockFetchChats(limit: number = 20, offsetDate?: number, of
 }
 
 export async function mockFetchChat(chatId: string) {
-  await new Promise(resolve => setTimeout(resolve, 300));
-  
-  const chat = mockChats.find(c => c.id === chatId);
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  let chat = mockChats.find((c) => c.id === chatId);
   if (!chat) {
-    throw new Error('Chat not found');
+    chat = {
+      id: chatId,
+      type: 'chats',
+      title: `Mock Chat ${chatId}`,
+      unreadCount: 0,
+      isPinned: false,
+      isArchived: false,
+    };
+    mockChats.push(chat);
   }
-  
+
   return {
     chat,
     users: [],


### PR DESCRIPTION
## Summary
- Auto-create placeholder chats in mock API instead of throwing "Chat not found"
- Document chat mocking behavior in main README
- Add notes about push subscription failures in separate file

## Testing
- `npm test` *(fails: node: --no-experimental-strip-types is not allowed in NODE_OPTIONS)*

------
https://chatgpt.com/codex/tasks/task_b_68a04941332483228266064e0799b3e7