### PR TITLE
fix: guard against missing peer color data

### DIFF
--- a/src/global/helpers/chats.ts
+++ b/src/global/helpers/chats.ts
@@ -372,7 +372,7 @@ export function getPeerColorKey(peer: ApiPeer | undefined) {
 export function getPeerColorCount(peer: ApiPeer) {
   const key = getPeerColorKey(peer);
   const global = getGlobal();
-  return global.peerColors?.general[key].colors?.length || 1;
+  return global.peerColors?.general?.[key]?.colors?.length || 1;
 }
 
 export function getIsSavedDialog(chatId: string, threadId: ThreadId | undefined, currentUserId: string | undefined) {


### PR DESCRIPTION
## Summary
- handle absent peer color data when determining color count

## Testing
- `env NODE_OPTIONS="" APP_ENV=test ./node_modules/.bin/jest --verbose --silent --forceExit`
- `env NODE_OPTIONS="" ./node_modules/.bin/tsc -p tsconfig.json` *(fails: Property 'version' does not exist on type '{}')*
- `env NODE_OPTIONS="" ./node_modules/.bin/eslint src/global/helpers/chats.ts`

------
https://chatgpt.com/codex/tasks/task_b_68a0563ecbec8322b46fe0396bfae201