### PR TITLE
fix: ensure reactions menu appears

### DIFF
--- a/src/components/middle/message/MessageContextMenu.tsx
+++ b/src/components/middle/message/MessageContextMenu.tsx
@@ -238,7 +238,8 @@ const MessageContextMenu: FC<OwnProps> = ({
   const scrollableRef = useRef<HTMLDivElement>();
   const oldLang = useOldLang();
   const lang = useLang();
-  const noReactions = !isPrivate && !enabledReactions;
+  const noReactions = !isPrivate && enabledReactions?.type === 'some'
+    && enabledReactions.allowed.length === 0;
   const areReactionsPossible = message.areReactionsPossible;
   const withReactions = (canShowReactionList && !noReactions) || areReactionsPossible;
   const isEdited = ('isEdited' in message) && message.isEdited;

--- a/src/components/middle/message/reactions/ReactionSelector.tsx
+++ b/src/components/middle/message/reactions/ReactionSelector.tsx
@@ -109,7 +109,7 @@ const ReactionSelector: FC<OwnProps> = ({
       if ((!isCustomReaction && !availableReaction) || availableReaction?.isInactive) return undefined;
 
       if (!isPrivate && !shouldUseCurrentReactions
-        && (!enabledReactions || !canSendReaction(reaction, enabledReactions))) {
+        && enabledReactions && !canSendReaction(reaction, enabledReactions)) {
         return undefined;
       }
 


### PR DESCRIPTION
## Summary
- show reaction menu when chat allows all reactions
- check for empty explicit reaction lists only when chat restricts reactions

## Testing
- `./node_modules/.bin/jest --verbose --silent --forceExit`
- `./node_modules/.bin/tsc -p tsconfig.json` *(fails: Module and type errors)*
- `./node_modules/.bin/eslint src/components/middle/message/reactions/ReactionSelector.tsx src/components/middle/message/MessageContextMenu.tsx` *(fails: RangeError: Maximum call stack size exceeded)*
- `./node_modules/.bin/stylelint src/components/middle/message/reactions/ReactionSelector.tsx src/components/middle/message/MessageContextMenu.tsx` *(fails: Unknown word FC CssSyntaxError)*

------
https://chatgpt.com/codex/tasks/task_b_68a059738eb0832293574102ee22af02